### PR TITLE
Moved true, false and null to the deprecated list

### DIFF
--- a/js/ace-127/mode-vyper.js
+++ b/js/ace-127/mode-vyper.js
@@ -45,7 +45,7 @@ var VyperHighlightRules = function() {
 	);
 
 	var builtinConstants = (
-		"true|false|True|False|None|NotImplemented|Ellipsis|ERC20|ether|wei|finney|" +
+		"True|False|None|NotImplemented|Ellipsis|ERC20|ether|wei|finney|" +
 		"szabo|shannon|lovelace|ada|babbage|gwei|kwei|mwei|twei|pwei"
 	);
 
@@ -61,7 +61,7 @@ var VyperHighlightRules = function() {
 
 	//var futureReserved = "";
 	var keywordMapper = this.createKeywordMapper({
-		"invalid.deprecated": "internal|__log__|num|num256|while",
+		"invalid.deprecated": "internal|__log__|num|num256|while|true|false|null",
 		"support.function": builtinFunctions,
 		"variable.language": "self|cls|msg|block",
 		"constant.language": builtinConstants,


### PR DESCRIPTION
Moved true, false (the lowercased version) and null to the deprecated list as they will soon become completely unsupported.
(Check out issue #742 and PR #756 in the Vyper repository)